### PR TITLE
Tweak the DOM to made some #magicPresentations easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+CHANGELOG.html

--- a/1900-01-01_R0-0.md
+++ b/1900-01-01_R0-0.md
@@ -1,20 +1,26 @@
 ## [R0.0] - 1900-01-01
+
+* This is just a sample file for how the actual notes should be structured. *
+
 ### Added
+
 - Concise, bulleted point that describes what was added.
 - Many things can be added.
 - Use the Notes section below to go into great detail
 - This section can be completely gone if nothing was added.
 
 ### Changed
+
 - Describe somethng that changed in the release.
 - Again this section is optional
 
 ### Fixed
+
 - Bugs fixes and typo fixes can be captured here.
 - Also optional if there were nothing "fixed"
 
 ### Notes
 
-This section should contain long-form content pertinent to the release. 
+This section should contain long-form content pertinent to the release.
 
 Be sure to leave an empty line at the bottom of the file!

--- a/1900-01-01_R0-0.md
+++ b/1900-01-01_R0-0.md
@@ -1,4 +1,4 @@
-## [R0.0] - 1900-01-01
+## R0.0 - 1900-01-01
 
 * This is just a sample file for how the actual notes should be structured. *
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to the Best Buy API will be documented in this file.
 
 
+<div class="log-toc">
+
+## Releases
+ - [[R11.1] - 2011-05-01](#user-content-r11-1-2011-05-01)
+</div>
+<div class="log-entry">
+
 ## [R11.1] - 2011-05-01
 
 ### Added
@@ -10,3 +17,4 @@ All notable changes to the Best Buy API will be documented in this file.
   - `preowned` - "Used" products
   - `digital` - Products available via download (not available in stores)
 
+</div>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 All notable changes to the Best Buy API will be documented in this file.
 
 
-<div class="log-toc">
-
-## Releases
- - [R11.1 - 2011-05-01](#r11-1---2011-05-01)
-</div>
 <div class="log-entry">
 
 ## R11.1 - 2011-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to the Best Buy API will be documented in this file.
 <div class="log-toc">
 
 ## Releases
- - [[R11.1] - 2011-05-01](#user-content-r11-1-2011-05-01)
+ - [R11.1 - 2011-05-01](#r11-1---2011-05-01)
 </div>
 <div class="log-entry">
 
-## [R11.1] - 2011-05-01
+## R11.1 - 2011-05-01
 
 ### Added
 - Three new **[Products API](https://bestbuyapis.github.io/api-documentation/#products-api)** attributes:

--- a/bin/render.js
+++ b/bin/render.js
@@ -1,0 +1,23 @@
+'use strict';
+/**
+ * This is just a copy of the marky-markdown binary
+ * except that it doesn't sanitize the output.
+ **/
+var fs = require('fs');
+var path = require('path');
+var marky = require('marky-markdown');
+
+if (process.argv.length < 3) {
+  console.log('Usage:\n\nmarky-markdown some.md > some.html');
+  process.exit();
+}
+
+var filePath = path.resolve(process.cwd(), process.argv[2]);
+
+fs.readFile(filePath, function (err, data) {
+  if (err) {
+    throw err;
+  }
+  var $ = marky(data.toString(), {sanitize: false});
+  process.stdout.write($.html());
+});

--- a/bin/render.js
+++ b/bin/render.js
@@ -18,6 +18,6 @@ fs.readFile(filePath, function (err, data) {
   if (err) {
     throw err;
   }
-  var $ = marky(data.toString(), {sanitize: false});
+  var $ = marky(data.toString(), {sanitize: false, prefixHeadingIds: false});
   process.stdout.write($.html());
 });

--- a/build-changelog.js
+++ b/build-changelog.js
@@ -2,17 +2,12 @@
 var fs = require('fs');
 var path = require('path');
 
-function convertTitleToId (title) {
-  return title.toLowerCase().replace(/[^\w\-]+/g, ' ').trim().replace(/\s/g, '-');
-}
-
 console.log('Building Changelog...');
 var notesPath = path.join('notes');
 
 var notes = fs.readdirSync(notesPath);
 
 var changelogHeader = '';
-var changelogEntries = [];
 var changelogData = '';
 
 console.log('Processing ' + notes.length + ' files.');
@@ -24,24 +19,15 @@ notes.sort().reverse().forEach(function (note) {
   } else {
     var changelogEntry = fs.readFileSync(path.join(notesPath, note), 'utf8');
     var firstLine = changelogEntry.split('\n')[0];
-    if (/^## R[\d\.]+\s-\s\d\d\d\d-\d\d-\d\d$/.test(firstLine) === false) {
+    if (/^## R[\d\.]+\s\-\s\d\d\d\d-\d\d-\d\d$/.test(firstLine) === false) {
       console.warn('First line of ' + note + ' does not match appropriate format');
       process.exit(1);
     }
-    changelogEntries.push(firstLine.substring(3));
     changelogData += '<div class="log-entry">\n\n';
     changelogData += changelogEntry + '\n';
     changelogData += '</div>\n';
   }
 });
-
-var changelogTOC = '<div class="log-toc">\n\n';
-changelogTOC += '## Releases\n';
-changelogEntries.forEach(function (entry) {
-  changelogTOC += ' - [' + entry + '](#' + convertTitleToId(entry) + ')\n';
-});
-changelogTOC += '</div>\n';
-
-fs.writeFileSync('CHANGELOG.md', changelogHeader + changelogTOC + changelogData, 'utf8');
+fs.writeFileSync('CHANGELOG.md', changelogHeader + changelogData, 'utf8');
 
 console.log('Done!');

--- a/build-changelog.js
+++ b/build-changelog.js
@@ -1,27 +1,51 @@
-'use strict'
-var fs = require('fs')
+'use strict';
+var fs = require('fs');
+var path = require('path');
 
-var path = require('path')
+function convertTitleToId (title) {
+  return title.toLowerCase().replace(/[^\w]+/g, ' ').trim().replace(/\s/g, '-');
+}
 
-console.log('Building Changelog...')
-var notesPath = path.join('notes')
+console.log('Building Changelog...');
+var notesPath = path.join('notes');
 
-var notes = fs.readdirSync(notesPath)
+var notes = fs.readdirSync(notesPath);
 
-var changelogHeader = ''
-var changelogData = ''
+var changelogHeader = '';
+var changelogEntries = [];
+var changelogTOC = '';
+var changelogData = '';
+var changelogEntry = '';
+var firstLine = '';
+var firstLineRegex = /^## \[R[\d\.]+\]\s-\s\d\d\d\d-\d\d-\d\d$/;
 
-console.log('Processing ' + notes.length + ' files.')
+console.log('Processing ' + notes.length + ' files.');
 
-notes.reverse().forEach(function (note) {
-  console.log(path.parse(note).name)
+notes.sort().reverse().forEach(function (note) {
+  console.log('\t' + path.parse(note).name);
   if (path.parse(note).name === '_header') {
-    changelogHeader = fs.readFileSync(path.join(notesPath, note), 'utf8') + '\n\n'
+    changelogHeader = fs.readFileSync(path.join(notesPath, note), 'utf8') + '\n\n';
   } else {
-    changelogData += fs.readFileSync(path.join(notesPath, note), 'utf8') + '\n'
+    changelogEntry = fs.readFileSync(path.join(notesPath, note), 'utf8');
+    firstLine = changelogEntry.split('\n')[0];
+    if (firstLineRegex.test(firstLine) === false) {
+      console.warn('First line of ' + note + ' does not match appropriate format');
+      process.exit(1);
+    }
+    changelogEntries.push(changelogEntry.split('\n')[0].substring(3));
+    changelogData += '<div class="log-entry">\n\n';
+    changelogData += changelogEntry + '\n';
+    changelogData += '</div>\n';
   }
-})
+});
 
-fs.writeFileSync('CHANGELOG.md', changelogHeader + changelogData, 'utf8')
+changelogTOC = '<div class="log-toc">\n\n';
+changelogTOC += '## Releases\n';
+changelogEntries.forEach(function (entry) {
+  changelogTOC += ' - [' + entry + '](#user-content-' + convertTitleToId(entry) + ')\n';
+});
+changelogTOC += '</div>\n';
 
-console.log('Done!')
+fs.writeFileSync('CHANGELOG.md', changelogHeader + changelogTOC + changelogData, 'utf8');
+
+console.log('Done!');

--- a/build-changelog.js
+++ b/build-changelog.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 
 function convertTitleToId (title) {
-  return title.toLowerCase().replace(/[^\w]+/g, ' ').trim().replace(/\s/g, '-');
+  return title.toLowerCase().replace(/[^\w\-]+/g, ' ').trim().replace(/\s/g, '-');
 }
 
 console.log('Building Changelog...');
@@ -13,11 +13,7 @@ var notes = fs.readdirSync(notesPath);
 
 var changelogHeader = '';
 var changelogEntries = [];
-var changelogTOC = '';
 var changelogData = '';
-var changelogEntry = '';
-var firstLine = '';
-var firstLineRegex = /^## \[R[\d\.]+\]\s-\s\d\d\d\d-\d\d-\d\d$/;
 
 console.log('Processing ' + notes.length + ' files.');
 
@@ -26,23 +22,23 @@ notes.sort().reverse().forEach(function (note) {
   if (path.parse(note).name === '_header') {
     changelogHeader = fs.readFileSync(path.join(notesPath, note), 'utf8') + '\n\n';
   } else {
-    changelogEntry = fs.readFileSync(path.join(notesPath, note), 'utf8');
-    firstLine = changelogEntry.split('\n')[0];
-    if (firstLineRegex.test(firstLine) === false) {
+    var changelogEntry = fs.readFileSync(path.join(notesPath, note), 'utf8');
+    var firstLine = changelogEntry.split('\n')[0];
+    if (/^## R[\d\.]+\s-\s\d\d\d\d-\d\d-\d\d$/.test(firstLine) === false) {
       console.warn('First line of ' + note + ' does not match appropriate format');
       process.exit(1);
     }
-    changelogEntries.push(changelogEntry.split('\n')[0].substring(3));
+    changelogEntries.push(firstLine.substring(3));
     changelogData += '<div class="log-entry">\n\n';
     changelogData += changelogEntry + '\n';
     changelogData += '</div>\n';
   }
 });
 
-changelogTOC = '<div class="log-toc">\n\n';
+var changelogTOC = '<div class="log-toc">\n\n';
 changelogTOC += '## Releases\n';
 changelogEntries.forEach(function (entry) {
-  changelogTOC += ' - [' + entry + '](#user-content-' + convertTitleToId(entry) + ')\n';
+  changelogTOC += ' - [' + entry + '](#' + convertTitleToId(entry) + ')\n';
 });
 changelogTOC += '</div>\n';
 

--- a/notes/2011-05-01_R11-1.md
+++ b/notes/2011-05-01_R11-1.md
@@ -1,4 +1,4 @@
-## [R11.1] - 2011-05-01
+## R11.1 - 2011-05-01
 
 ### Added
 - Three new **[Products API](https://bestbuyapis.github.io/api-documentation/#products-api)** attributes:

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "api-release-notes",
   "version": "1.0.0",
   "description": "All release notes for the develoer.bestbuy.com API",
+  "engines" : { "node" : ">=0.12" },
   "main": "build-changelog.js",
   "scripts": {
-    "test": "standard",
-    "start": "node . "
+    "test": "semistandard",
+    "start": "node .",
+    "render": "npm start && node ./bin/render CHANGELOG.md > CHANGELOG.html"
   },
   "repository": {
     "type": "git",
@@ -15,6 +17,10 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/BestBuyAPIs/api-release-notes/issues"
+  },
+  "devDependencies": {
+    "marky-markdown": "~5.5.1",
+    "semistandard": "~7.0.4"
   },
   "homepage": "https://github.com/BestBuyAPIs/api-release-notes#readme"
 }


### PR DESCRIPTION
Also:
- Verifies the first line of every changelog entry
- Makes each entry DOM-friendly
- Switches to semistandard, because #semicolons
- Adds a `npm run render` script, because sometimes seeing the HTML is handy
